### PR TITLE
Add strict options

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,6 @@
+{
+  "extends": [
+  	"./index.js",
+  	"./strict-addons/vanilla-js/index.js"
+  ]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/index.js
+++ b/index.js
@@ -37,11 +37,11 @@ module.exports = {
         // disallow the use of debugger
         "no-debugger": 2,
 
-        // 	disallow unnecessary semicolons
-        "no-extra-semi": 2,
-
         // 	disallow unnecessary parentheses only around function expressions
         "no-extra-parens": [ 2, "functions" ],
+
+        //  disallow unnecessary semicolons
+        "no-extra-semi": 2,
 
         // allow irregular whitespace outside of strings and comments
         "no-irregular-whitespace": 0,

--- a/index.js
+++ b/index.js
@@ -109,6 +109,9 @@ module.exports = {
         // [revent variables used in JSX to be incorrectly marked as unused
         "react/jsx-uses-vars": 2,
 
+        // prevent missing parentheses around multilines JSX
+        "react/jsx-wrap-multilines": 2,
+
         // allow usage of dangerous JSX properties
         "react/no-danger": 0,
 
@@ -144,8 +147,5 @@ module.exports = {
 
         // enforce component methods order
         "react/sort-comp": 2,
-
-        // prevent missing parentheses around multilines JSX
-        "react/jsx-wrap-multilines": 2
       }
 };

--- a/index.js
+++ b/index.js
@@ -144,6 +144,6 @@ module.exports = {
         "react/sort-comp": 2,
 
         // prevent missing parentheses around multilines JSX
-        "react/wrap-multilines": 2
+        "react/jsx-wrap-multilines": 2
       }
 };

--- a/index.js
+++ b/index.js
@@ -1,151 +1,151 @@
 module.exports = {
-    "parser": "babel-eslint",
-    "parserOptions": {
-        "ecmaFeatures": {
-            "jsx": true
+    'parser': 'babel-eslint',
+    'parserOptions': {
+        'ecmaFeatures': {
+            'jsx': true
         }
     },
-    "ecmaFeatures": {
-        "jsx": true
+    'ecmaFeatures': {
+        'jsx': true
     },
-    "env": {
-		"amd": true,
-		"browser": true,
-		"jquery": true,
-		"node": true,
-		"es6": true,
-		"worker": true
-	},
-    "plugins": [
-        "react"
+    'env': {
+        'amd': true,
+        'browser': true,
+        'jquery': true,
+        'node': true,
+        'es6': true,
+        'worker': true
+    },
+    'plugins': [
+        'react'
     ],
-    "rules": {
+    'rules': {
         // require the use of === and !==, except in certain cases
         // where it makes sense to use == and !=
         // http://eslint.org/docs/rules/eqeqeq
-        "eqeqeq": ["error", "smart"],
+        'eqeqeq': ['error', 'smart'],
 
         // 	disallow trailing commas
-        "comma-dangle": [2, "never"],
+        'comma-dangle': [2, 'never'],
 
         // enforce consistent indentation of 4 spaces
-        "indent": [ "error", 4 ],
+        'indent': [ 'error', 4 ],
 
         // allow the use of console
-        "no-console": 0,
+        'no-console': 0,
 
         // disallow the use of debugger
-        "no-debugger": 2,
+        'no-debugger': 2,
 
         // 	disallow unnecessary parentheses only around function expressions
-        "no-extra-parens": [ 2, "functions" ],
+        'no-extra-parens': [ 2, 'functions' ],
 
         //  disallow unnecessary semicolons
-        "no-extra-semi": 2,
+        'no-extra-semi': 2,
 
         // allow irregular whitespace outside of strings and comments
-        "no-irregular-whitespace": 0,
+        'no-irregular-whitespace': 0,
 
         // allow the use of undeclared and disallow use of unused variables
-        "no-undef": 0,
-        "no-unused-vars": [2, { "args": "none", "ignoreRestSiblings": true }],
+        'no-undef': 0,
+        'no-unused-vars': [2, { 'args': 'none', 'ignoreRestSiblings': true }],
 
         // enforce consistent spacing inside braces
-        "object-curly-spacing": [2, "always"],
+        'object-curly-spacing': [2, 'always'],
 
         // require semicolons instead of ASI
-        "semi": 2,
+        'semi': 2,
 
         // enforces spacing after semicolons and disallows spacing before semicolons
-        "semi-spacing": 2,
+        'semi-spacing': 2,
 
         // require single quotes where possible and allow strings to use backtick
-        "quotes": [2, "single", { "allowTemplateLiterals": true }],
+        'quotes': [2, 'single', { 'allowTemplateLiterals': true }],
 
         // 	enforce valid JSDoc comments
-        "valid-jsdoc": [
-          2,
-          { "requireReturn": false }
+        'valid-jsdoc': [
+            2,
+          { 'requireReturn': false }
         ],
 
         // React rules
 
         // enforces closing bracket after props always
-        "react/jsx-closing-bracket-location": [
-          2,
-          {
-            "selfClosing": "after-props",
-            "nonEmpty": "after-props"
-          }
+        'react/jsx-closing-bracket-location': [
+            2,
+            {
+                'selfClosing': 'after-props',
+                'nonEmpty': 'after-props'
+            }
         ],
 
         // enforce spaces between curly braces
-        "react/jsx-curly-spacing": 2,
+        'react/jsx-curly-spacing': 2,
 
         // do not enforce consistent props indentation
-        "react/jsx-indent-props": 0,
+        'react/jsx-indent-props': 0,
 
         // do not enforce max props per line
-        "react/jsx-max-props-per-line": 0,
+        'react/jsx-max-props-per-line': 0,
 
         // prevent duplicate props in JSX
-        "react/jsx-no-duplicate-props": 2,
+        'react/jsx-no-duplicate-props': 2,
 
         // allow unwrapped literals (e.g. {'test'} vs test)
-        "react/jsx-no-literals": 0,
+        'react/jsx-no-literals': 0,
 
         // disallow undeclared variables
-        "react/jsx-no-undef": 2,
+        'react/jsx-no-undef': 2,
 
         // require prop types to be alpha sorted
-        "react/sort-prop-types": 2,
+        'react/sort-prop-types': 2,
 
         // do not enforce alpha sorted props passed in
-        "react/jsx-sort-props": 0,
+        'react/jsx-sort-props': 0,
 
         // prevent React to be incorrectly marked as unused
-        "react/jsx-uses-react": 2,
+        'react/jsx-uses-react': 2,
 
         // [revent variables used in JSX to be incorrectly marked as unused
-        "react/jsx-uses-vars": 2,
+        'react/jsx-uses-vars': 2,
 
         // prevent missing parentheses around multilines JSX
-        "react/jsx-wrap-multilines": 2,
+        'react/jsx-wrap-multilines': 2,
 
         // allow usage of dangerous JSX properties
-        "react/no-danger": 0,
+        'react/no-danger': 0,
 
         // prevent usage of setState in componentDidMount
-        "react/no-did-mount-set-state": 2,
+        'react/no-did-mount-set-state': 2,
 
         // prevent uage of setSate in componentDidUpdate
-        "react/no-did-update-set-state": 2,
+        'react/no-did-update-set-state': 2,
 
         // prevent direct mutation of this.state
-        "react/no-direct-mutation-state": 2,
+        'react/no-direct-mutation-state': 2,
 
         // prevent multiple component definition per file except for stateless components
-        "react/no-multi-comp": [
-          2,
-          { "ignoreStateless": true }
+        'react/no-multi-comp': [
+            2,
+          { 'ignoreStateless': true }
         ],
 
         // allow usage of setState
-        "react/no-set-state": 0,
+        'react/no-set-state': 0,
 
         // warn on usage of unknown DOM property
-        "react/no-unknown-property": 1,
+        'react/no-unknown-property': 1,
 
         // prevent missing props validation in a React component definition
-        "react/prop-types": [2, { "ignore": ["children"] }],
+        'react/prop-types': [2, { 'ignore': ['children'] }],
 
         // prevent missing React when using JSX
-        "react/react-in-jsx-scope": 0,
+        'react/react-in-jsx-scope': 0,
 
         // prevent extra closing tags for components without children
-        "react/self-closing-comp": 2,
+        'react/self-closing-comp': 2,
 
         // enforce component methods order
-        "react/sort-comp": 2,
-      }
+        'react/sort-comp': 2
+    }
 };

--- a/index.js
+++ b/index.js
@@ -20,8 +20,10 @@ module.exports = {
         "react"
     ],
     "rules": {
-        // require the use of === and !==
-        "eqeqeq": 2,
+        // require the use of === and !==, except in certain cases
+        // where it makes sense to use == and !=
+        // http://eslint.org/docs/rules/eqeqeq
+        "eqeqeq": ["error", "smart"],
 
         // 	disallow trailing commas
         "comma-dangle": [2, "never"],

--- a/package.json
+++ b/package.json
@@ -30,5 +30,8 @@
       "eslint": ">= 3",
       "eslint-plugin-react": ">= 5",
       "babel-eslint": ">= 6"
+  },
+  "scripts": {
+      "lint": "eslint . --fix --quiet"
   }
 }

--- a/strict-addons/vanilla-js/index.js
+++ b/strict-addons/vanilla-js/index.js
@@ -153,21 +153,8 @@ module.exports = {
     'no-octal-escape': 'error',
 
     // disallow reassignment of function parameters
-    // disallow parameter object manipulation except for specific exclusions
     // rule: http://eslint.org/docs/rules/no-param-reassign.html
-    'no-param-reassign': ['error', {
-      props: true,
-      ignorePropertyModificationsFor: [
-        'acc', // for reduce accumulators
-        'e', // for e.returnvalue
-        'ctx', // for Koa routing
-        'req', // for Express requests
-        'request', // for Express requests
-        'res', // for Express responses
-        'response', // for Express responses
-        '$scope', // for Angular 1 scopes
-      ]
-    }],
+    'no-param-reassign': 'error',
 
     // disallow usage of __proto__ property
     'no-proto': 'error',

--- a/strict-addons/vanilla-js/index.js
+++ b/strict-addons/vanilla-js/index.js
@@ -1,3 +1,4 @@
+/* Rules for vanilla javascript */
 module.exports = {
   rules: {
     // enforces getter/setter pairs in objects
@@ -43,6 +44,10 @@ module.exports = {
     // disallow the use of alert, confirm, and prompt
     'no-alert': 'warn',
 
+    // Disallow await inside of loops
+    // http://eslint.org/docs/rules/no-await-in-loop
+    'no-await-in-loop': 'error',
+
     // disallow use of arguments.caller or arguments.callee
     'no-caller': 'error',
 
@@ -50,12 +55,53 @@ module.exports = {
     // http://eslint.org/docs/rules/no-case-declarations.html
     'no-case-declarations': 'error',
 
+    // Disallow comparisons to negative zero
+    // http://eslint.org/docs/rules/no-compare-neg-zero
+    'no-compare-neg-zero': 'off',
+
+    // disallow assignment in conditional expressions
+    // this prevents difficult to spot bugs when you think you're doing a comparison,
+    // e.g. if (x = 0) { ... }
+    'no-cond-assign': ['error', 'always'],
+
+    // disallow use of constant expressions in conditions
+    // use of these rarely used characters in a regex is typically a mistake
+    // http://eslint.org/docs/rules/no-control-regex
+    'no-constant-condition': 'warn',
+
+    // disallow control characters in regular expressions
+    'no-control-regex': 'error',
+
     // disallow division operators explicitly at beginning of regular expression
     // http://eslint.org/docs/rules/no-div-regex
     'no-div-regex': 'off',
 
+    // disallow duplicate arguments in functions
+    // never a reason to have duplicate args, as only one will pass through
+    // probably a typo
+    'no-dupe-args': 'error',
+
+    // disallow duplicate keys when creating object literals
+    // like dupe args, always a mistake, as only one key is used
+    'no-dupe-keys': 'error',
+
+    // disallow a duplicate case in a switch statement
+    // another common mistake - only one can be used
+    'no-duplicate-case': 'error',
+
     // disallow else after a return in an if
     'no-else-return': 'error',
+
+    // disallow empty blocks
+    // e.g., if (foo) {}
+    // You can put a comment in your empty block to prevent the error
+    // http://eslint.org/docs/rules/no-empty
+    'no-empty': 'error',
+
+    // disallow the use of empty character classes in regular expressions
+    // [] in a regex doesn't match anything
+    // http://eslint.org/docs/rules/no-empty-character-class
+    'no-empty-character-class': 'error',
 
     // disallow empty functions, except for standalone funcs/arrows
     // http://eslint.org/docs/rules/no-empty-function
@@ -77,11 +123,21 @@ module.exports = {
     // disallow use of eval()
     'no-eval': 'error',
 
+    // disallow assigning to the exception in a catch block
+    // this loses the information about the exception
+    // http://eslint.org/docs/rules/no-ex-assign
+    'no-ex-assign': 'error',
+
     // disallow adding to native types
     'no-extend-native': 'error',
 
     // disallow unnecessary function binding
     'no-extra-bind': 'error',
+
+    // disallow double-negation boolean casts in a boolean context
+    // for example, unnecessary in an if statement's check
+    // http://eslint.org/docs/rules/no-extra-boolean-cast
+    'no-extra-boolean-cast': 'error',
 
     // disallow Unnecessary Labels
     // http://eslint.org/docs/rules/no-extra-label
@@ -93,9 +149,16 @@ module.exports = {
     // disallow the use of leading or trailing decimal points in numeric literals
     'no-floating-decimal': 'error',
 
+    // disallow overwriting functions written as function declarations
+    'no-func-assign': 'error',
+
     // disallow reassignments of native objects or read-only globals
     // http://eslint.org/docs/rules/no-global-assign
     'no-global-assign': ['error', { exceptions: [] }],
+
+    // disallow invalid regular expression strings in the RegExp constructor
+    'no-invalid-regexp': ['error', { "allowConstructorFlags": ["u", "y"] }],
+
     // deprecated in favor of no-global-assign
     'no-native-reassign': 'off',
 
@@ -145,6 +208,9 @@ module.exports = {
     // disallows creating new instances of String, Number, and Boolean
     'no-new-wrappers': 'error',
 
+    // disallow the use of object properties of the global object (Math and JSON) as functions
+    'no-obj-calls': 'error',
+
     // disallow use of (old style) octal literals
     'no-octal': 'error',
 
@@ -159,8 +225,15 @@ module.exports = {
     // disallow usage of __proto__ property
     'no-proto': 'error',
 
+    // disallow use of Object.prototypes builtins directly
+    // http://eslint.org/docs/rules/no-prototype-builtins
+    'no-prototype-builtins': 'error',
+
     // disallow declaring the same variable more then once
     'no-redeclare': 'error',
+
+    // disallow multiple spaces in a regular expression literal
+    'no-regex-spaces': 'error',
 
     // disallow certain object properties
     // http://eslint.org/docs/rules/no-restricted-properties
@@ -199,12 +272,41 @@ module.exports = {
     // disallow use of comma operator
     'no-sequences': 'error',
 
+    // disallow sparse arrays
+    // e.g. [,,] - typically caused by accidentally typing extra commas
+    'no-sparse-arrays': 'error',
+
+    // Disallow template literal placeholder syntax in regular strings
+    // Probably happens when you switch from template to a regular string, but forget
+    // to remove the placeholders
+    // http://eslint.org/docs/rules/no-template-curly-in-string
+    'no-template-curly-in-string': 'error',
+
     // restrict what can be thrown as an exception
     'no-throw-literal': 'error',
+
+    // Avoid code that looks like two expressions but is actually one
+    // http://eslint.org/docs/rules/no-unexpected-multiline
+    'no-unexpected-multiline': 'error',
 
     // disallow unmodified conditions of loops
     // http://eslint.org/docs/rules/no-unmodified-loop-condition
     'no-unmodified-loop-condition': 'off',
+
+    // disallow unreachable statements after a return, throw, continue, or break statement
+    // you may have intended for the code to be reachable, or may have forgotten
+    // to delete it
+    // http://eslint.org/docs/rules/no-unreachable
+    'no-unreachable': 'error',
+
+    // disallow return/throw/break/continue inside finally blocks
+    // http://eslint.org/docs/rules/no-unsafe-finally
+    'no-unsafe-finally': 'error',
+
+    // disallow negating the left operand of relational operators
+    // prevents mistakes like !a && b when you mean !(a && b)
+    // http://eslint.org/docs/rules/no-unsafe-negation
+    'no-unsafe-negation': 'error',
 
     // disallow usage of expressions in statement position
     'no-unused-expressions': ['error', {
@@ -254,6 +356,15 @@ module.exports = {
     // http://eslint.org/docs/rules/require-await
     'require-await': 'off',
 
+    // disallow comparisons with the value NaN
+    // NaN behaves unexpectedly, whereas isNaN(foo) does not
+    // http://eslint.org/docs/rules/use-isnan
+    'use-isnan': 'error',
+
+    // ensure that the results of typeof are compared against a valid string
+    // http://eslint.org/docs/rules/valid-typeof
+    'valid-typeof': ['error', { requireStringLiterals: true }],
+
     // requires to declare all vars on top of their containing scope
     'vars-on-top': 'error',
 
@@ -263,5 +374,5 @@ module.exports = {
 
     // require or disallow Yoda conditions
     yoda: 'error'
-  }
+  },
 };

--- a/strict-addons/vanilla-js/index.js
+++ b/strict-addons/vanilla-js/index.js
@@ -1,0 +1,280 @@
+module.exports = {
+  rules: {
+    // enforces getter/setter pairs in objects
+    'accessor-pairs': 'off',
+
+    // enforces return statements in callbacks of array's methods
+    // http://eslint.org/docs/rules/array-callback-return
+    'array-callback-return': 'error',
+
+    // treat var statements as if they were block scoped
+    'block-scoped-var': 'error',
+
+    // specify the maximum cyclomatic complexity allowed in a program
+    complexity: ['off', 11],
+
+    // enforce that class methods use "this"
+    // http://eslint.org/docs/rules/class-methods-use-this
+    'class-methods-use-this': ['error', {
+      exceptMethods: [],
+    }],
+
+    // require return statements to either always or never specify values
+    'consistent-return': 'error',
+
+    // must use curly braces (no if (foo) bar();)
+    curly: ['error', 'all'],
+
+    // require default case in switch statements
+    'default-case': ['error', { commentPattern: '^no default$' }],
+
+    // encourages use of dot notation whenever possible
+    'dot-notation': ['error', { allowKeywords: true }],
+
+    // enforces consistent newlines before or after dots
+    // http://eslint.org/docs/rules/dot-location
+    'dot-location': ['error', 'property'],
+
+    // make sure for-in loops have an if statement
+    // this prevents unexpected behavior resulting from javascript's for-in
+    // being different from, say, C#
+    'guard-for-in': 'error',
+
+    // disallow the use of alert, confirm, and prompt
+    'no-alert': 'warn',
+
+    // disallow use of arguments.caller or arguments.callee
+    'no-caller': 'error',
+
+    // disallow lexical declarations in case/default clauses
+    // http://eslint.org/docs/rules/no-case-declarations.html
+    'no-case-declarations': 'error',
+
+    // disallow division operators explicitly at beginning of regular expression
+    // http://eslint.org/docs/rules/no-div-regex
+    'no-div-regex': 'off',
+
+    // disallow else after a return in an if
+    'no-else-return': 'error',
+
+    // disallow empty functions, except for standalone funcs/arrows
+    // http://eslint.org/docs/rules/no-empty-function
+    'no-empty-function': ['error', {
+      allow: [
+        'arrowFunctions',
+        'functions',
+        'methods',
+      ]
+    }],
+
+    // disallow empty destructuring patterns
+    // http://eslint.org/docs/rules/no-empty-pattern
+    'no-empty-pattern': 'error',
+
+    // disallow comparisons to null without a type-checking operator
+    'no-eq-null': 'off',
+
+    // disallow use of eval()
+    'no-eval': 'error',
+
+    // disallow adding to native types
+    'no-extend-native': 'error',
+
+    // disallow unnecessary function binding
+    'no-extra-bind': 'error',
+
+    // disallow Unnecessary Labels
+    // http://eslint.org/docs/rules/no-extra-label
+    'no-extra-label': 'error',
+
+    // disallow fallthrough of case statements
+    'no-fallthrough': 'error',
+
+    // disallow the use of leading or trailing decimal points in numeric literals
+    'no-floating-decimal': 'error',
+
+    // disallow reassignments of native objects or read-only globals
+    // http://eslint.org/docs/rules/no-global-assign
+    'no-global-assign': ['error', { exceptions: [] }],
+    // deprecated in favor of no-global-assign
+    'no-native-reassign': 'off',
+
+    // disallow implicit type conversions
+    // http://eslint.org/docs/rules/no-implicit-coercion
+    'no-implicit-coercion': ['off', {
+      boolean: false,
+      number: true,
+      string: true,
+      allow: [],
+    }],
+
+    // disallow var and named functions in global scope
+    // http://eslint.org/docs/rules/no-implicit-globals
+    'no-implicit-globals': 'off',
+
+    // disallow use of eval()-like methods
+    'no-implied-eval': 'error',
+
+    // disallow this keywords outside of classes or class-like objects
+    'no-invalid-this': 'off',
+
+    // disallow usage of __iterator__ property
+    'no-iterator': 'error',
+
+    // disallow use of labels for anything other then loops and switches
+    'no-labels': ['error', { allowLoop: false, allowSwitch: false }],
+
+    // disallow unnecessary nested blocks
+    'no-lone-blocks': 'error',
+
+    // disallow creation of functions within loops
+    'no-loop-func': 'error',
+
+    // disallow use of multiple spaces
+    'no-multi-spaces': 'error',
+
+    // disallow use of multiline strings
+    'no-multi-str': 'error',
+
+    // disallow use of new operator when not part of the assignment or comparison
+    'no-new': 'error',
+
+    // disallow use of new operator for Function object
+    'no-new-func': 'error',
+
+    // disallows creating new instances of String, Number, and Boolean
+    'no-new-wrappers': 'error',
+
+    // disallow use of (old style) octal literals
+    'no-octal': 'error',
+
+    // disallow use of octal escape sequences in string literals, such as
+    // var foo = 'Copyright \251';
+    'no-octal-escape': 'error',
+
+    // disallow reassignment of function parameters
+    // disallow parameter object manipulation except for specific exclusions
+    // rule: http://eslint.org/docs/rules/no-param-reassign.html
+    'no-param-reassign': ['error', {
+      props: true,
+      ignorePropertyModificationsFor: [
+        'acc', // for reduce accumulators
+        'e', // for e.returnvalue
+        'ctx', // for Koa routing
+        'req', // for Express requests
+        'request', // for Express requests
+        'res', // for Express responses
+        'response', // for Express responses
+        '$scope', // for Angular 1 scopes
+      ]
+    }],
+
+    // disallow usage of __proto__ property
+    'no-proto': 'error',
+
+    // disallow declaring the same variable more then once
+    'no-redeclare': 'error',
+
+    // disallow certain object properties
+    // http://eslint.org/docs/rules/no-restricted-properties
+    'no-restricted-properties': ['error', {
+      object: 'arguments',
+      property: 'callee',
+      message: 'arguments.callee is deprecated',
+    }, {
+      property: '__defineGetter__',
+      message: 'Please use Object.defineProperty instead.',
+    }, {
+      property: '__defineSetter__',
+      message: 'Please use Object.defineProperty instead.',
+    }, {
+      object: 'Math',
+      property: 'pow',
+      message: 'Use the exponentiation operator (**) instead.',
+    }],
+
+    // disallow use of assignment in return statement
+    'no-return-assign': 'error',
+
+    // disallow redundant `return await`
+    'no-return-await': 'error',
+
+    // disallow use of `javascript:` urls.
+    'no-script-url': 'error',
+
+    // disallow self assignment
+    // http://eslint.org/docs/rules/no-self-assign
+    'no-self-assign': 'error',
+
+    // disallow comparisons where both sides are exactly the same
+    'no-self-compare': 'error',
+
+    // disallow use of comma operator
+    'no-sequences': 'error',
+
+    // restrict what can be thrown as an exception
+    'no-throw-literal': 'error',
+
+    // disallow unmodified conditions of loops
+    // http://eslint.org/docs/rules/no-unmodified-loop-condition
+    'no-unmodified-loop-condition': 'off',
+
+    // disallow usage of expressions in statement position
+    'no-unused-expressions': ['error', {
+      allowShortCircuit: false,
+      allowTernary: false,
+      allowTaggedTemplates: false,
+    }],
+
+    // disallow unused labels
+    // http://eslint.org/docs/rules/no-unused-labels
+    'no-unused-labels': 'error',
+
+    // disallow unnecessary .call() and .apply()
+    'no-useless-call': 'off',
+
+    // disallow useless string concatenation
+    // http://eslint.org/docs/rules/no-useless-concat
+    'no-useless-concat': 'error',
+
+    // disallow unnecessary string escaping
+    // http://eslint.org/docs/rules/no-useless-escape
+    'no-useless-escape': 'error',
+
+    // disallow redundant return; keywords
+    // http://eslint.org/docs/rules/no-useless-return
+    'no-useless-return': 'error',
+
+    // disallow use of void operator
+    // http://eslint.org/docs/rules/no-void
+    'no-void': 'error',
+
+    // disallow usage of configurable warning terms in comments: e.g. todo
+    'no-warning-comments': ['off', { terms: ['todo', 'fixme', 'xxx'], location: 'start' }],
+
+    // disallow use of the with statement
+    'no-with': 'error',
+
+    // require using Error objects as Promise rejection reasons
+    // http://eslint.org/docs/rules/prefer-promise-reject-errors
+    // TODO: enable, semver-major
+    'prefer-promise-reject-errors': ['off', { allowEmptyReject: true }],
+
+    // require use of the second argument for parseInt()
+    radix: 'error',
+
+    // require `await` in `async function` (note: this is a horrible rule that should never be used)
+    // http://eslint.org/docs/rules/require-await
+    'require-await': 'off',
+
+    // requires to declare all vars on top of their containing scope
+    'vars-on-top': 'error',
+
+    // require immediate function invocation to be wrapped in parentheses
+    // http://eslint.org/docs/rules/wrap-iife.html
+    'wrap-iife': ['error', 'outside', { functionPrototypeMethods: false }],
+
+    // require or disallow Yoda conditions
+    yoda: 'error'
+  }
+};

--- a/strict-addons/vanilla-js/index.js
+++ b/strict-addons/vanilla-js/index.js
@@ -1,378 +1,378 @@
 /* Rules for vanilla javascript */
 module.exports = {
-  rules: {
+    rules: {
     // enforces getter/setter pairs in objects
-    'accessor-pairs': 'off',
+        'accessor-pairs': 'off',
 
     // enforces return statements in callbacks of array's methods
     // http://eslint.org/docs/rules/array-callback-return
-    'array-callback-return': 'error',
+        'array-callback-return': 'error',
 
     // treat var statements as if they were block scoped
-    'block-scoped-var': 'error',
+        'block-scoped-var': 'error',
 
     // specify the maximum cyclomatic complexity allowed in a program
-    complexity: ['off', 11],
+        complexity: ['off', 11],
 
     // enforce that class methods use "this"
     // http://eslint.org/docs/rules/class-methods-use-this
-    'class-methods-use-this': ['error', {
-      exceptMethods: [],
-    }],
+        'class-methods-use-this': ['error', {
+            exceptMethods: []
+        }],
 
     // require return statements to either always or never specify values
-    'consistent-return': 'error',
+        'consistent-return': 'error',
 
     // must use curly braces (no if (foo) bar();)
-    curly: ['error', 'all'],
+        curly: ['error', 'all'],
 
     // require default case in switch statements
-    'default-case': ['error', { commentPattern: '^no default$' }],
+        'default-case': ['error', { commentPattern: '^no default$' }],
 
     // encourages use of dot notation whenever possible
-    'dot-notation': ['error', { allowKeywords: true }],
+        'dot-notation': ['error', { allowKeywords: true }],
 
     // enforces consistent newlines before or after dots
     // http://eslint.org/docs/rules/dot-location
-    'dot-location': ['error', 'property'],
+        'dot-location': ['error', 'property'],
 
     // make sure for-in loops have an if statement
     // this prevents unexpected behavior resulting from javascript's for-in
     // being different from, say, C#
-    'guard-for-in': 'error',
+        'guard-for-in': 'error',
 
     // disallow the use of alert, confirm, and prompt
-    'no-alert': 'warn',
+        'no-alert': 'warn',
 
     // Disallow await inside of loops
     // http://eslint.org/docs/rules/no-await-in-loop
-    'no-await-in-loop': 'error',
+        'no-await-in-loop': 'error',
 
     // disallow use of arguments.caller or arguments.callee
-    'no-caller': 'error',
+        'no-caller': 'error',
 
     // disallow lexical declarations in case/default clauses
     // http://eslint.org/docs/rules/no-case-declarations.html
-    'no-case-declarations': 'error',
+        'no-case-declarations': 'error',
 
     // Disallow comparisons to negative zero
     // http://eslint.org/docs/rules/no-compare-neg-zero
-    'no-compare-neg-zero': 'off',
+        'no-compare-neg-zero': 'off',
 
     // disallow assignment in conditional expressions
     // this prevents difficult to spot bugs when you think you're doing a comparison,
     // e.g. if (x = 0) { ... }
-    'no-cond-assign': ['error', 'always'],
+        'no-cond-assign': ['error', 'always'],
 
     // disallow use of constant expressions in conditions
     // use of these rarely used characters in a regex is typically a mistake
     // http://eslint.org/docs/rules/no-control-regex
-    'no-constant-condition': 'warn',
+        'no-constant-condition': 'warn',
 
     // disallow control characters in regular expressions
-    'no-control-regex': 'error',
+        'no-control-regex': 'error',
 
     // disallow division operators explicitly at beginning of regular expression
     // http://eslint.org/docs/rules/no-div-regex
-    'no-div-regex': 'off',
+        'no-div-regex': 'off',
 
     // disallow duplicate arguments in functions
     // never a reason to have duplicate args, as only one will pass through
     // probably a typo
-    'no-dupe-args': 'error',
+        'no-dupe-args': 'error',
 
     // disallow duplicate keys when creating object literals
     // like dupe args, always a mistake, as only one key is used
-    'no-dupe-keys': 'error',
+        'no-dupe-keys': 'error',
 
     // disallow a duplicate case in a switch statement
     // another common mistake - only one can be used
-    'no-duplicate-case': 'error',
+        'no-duplicate-case': 'error',
 
     // disallow else after a return in an if
-    'no-else-return': 'error',
+        'no-else-return': 'error',
 
     // disallow empty blocks
     // e.g., if (foo) {}
     // You can put a comment in your empty block to prevent the error
     // http://eslint.org/docs/rules/no-empty
-    'no-empty': 'error',
+        'no-empty': 'error',
 
     // disallow the use of empty character classes in regular expressions
     // [] in a regex doesn't match anything
     // http://eslint.org/docs/rules/no-empty-character-class
-    'no-empty-character-class': 'error',
+        'no-empty-character-class': 'error',
 
     // disallow empty functions, except for standalone funcs/arrows
     // http://eslint.org/docs/rules/no-empty-function
-    'no-empty-function': ['error', {
-      allow: [
-        'arrowFunctions',
-        'functions',
-        'methods',
-      ]
-    }],
+        'no-empty-function': ['error', {
+            allow: [
+                'arrowFunctions',
+                'functions',
+                'methods'
+            ]
+        }],
 
     // disallow empty destructuring patterns
     // http://eslint.org/docs/rules/no-empty-pattern
-    'no-empty-pattern': 'error',
+        'no-empty-pattern': 'error',
 
     // disallow comparisons to null without a type-checking operator
-    'no-eq-null': 'off',
+        'no-eq-null': 'off',
 
     // disallow use of eval()
-    'no-eval': 'error',
+        'no-eval': 'error',
 
     // disallow assigning to the exception in a catch block
     // this loses the information about the exception
     // http://eslint.org/docs/rules/no-ex-assign
-    'no-ex-assign': 'error',
+        'no-ex-assign': 'error',
 
     // disallow adding to native types
-    'no-extend-native': 'error',
+        'no-extend-native': 'error',
 
     // disallow unnecessary function binding
-    'no-extra-bind': 'error',
+        'no-extra-bind': 'error',
 
     // disallow double-negation boolean casts in a boolean context
     // for example, unnecessary in an if statement's check
     // http://eslint.org/docs/rules/no-extra-boolean-cast
-    'no-extra-boolean-cast': 'error',
+        'no-extra-boolean-cast': 'error',
 
     // disallow Unnecessary Labels
     // http://eslint.org/docs/rules/no-extra-label
-    'no-extra-label': 'error',
+        'no-extra-label': 'error',
 
     // disallow fallthrough of case statements
-    'no-fallthrough': 'error',
+        'no-fallthrough': 'error',
 
     // disallow the use of leading or trailing decimal points in numeric literals
-    'no-floating-decimal': 'error',
+        'no-floating-decimal': 'error',
 
     // disallow overwriting functions written as function declarations
-    'no-func-assign': 'error',
+        'no-func-assign': 'error',
 
     // disallow reassignments of native objects or read-only globals
     // http://eslint.org/docs/rules/no-global-assign
-    'no-global-assign': ['error', { exceptions: [] }],
+        'no-global-assign': ['error', { exceptions: [] }],
 
     // disallow invalid regular expression strings in the RegExp constructor
-    'no-invalid-regexp': ['error', { "allowConstructorFlags": ["u", "y"] }],
+        'no-invalid-regexp': ['error', { 'allowConstructorFlags': ['u', 'y'] }],
 
     // deprecated in favor of no-global-assign
-    'no-native-reassign': 'off',
+        'no-native-reassign': 'off',
 
     // disallow implicit type conversions
     // http://eslint.org/docs/rules/no-implicit-coercion
-    'no-implicit-coercion': ['off', {
-      boolean: false,
-      number: true,
-      string: true,
-      allow: [],
-    }],
+        'no-implicit-coercion': ['off', {
+            boolean: false,
+            number: true,
+            string: true,
+            allow: []
+        }],
 
     // disallow var and named functions in global scope
     // http://eslint.org/docs/rules/no-implicit-globals
-    'no-implicit-globals': 'off',
+        'no-implicit-globals': 'off',
 
     // disallow use of eval()-like methods
-    'no-implied-eval': 'error',
+        'no-implied-eval': 'error',
 
     // disallow this keywords outside of classes or class-like objects
-    'no-invalid-this': 'off',
+        'no-invalid-this': 'off',
 
     // disallow usage of __iterator__ property
-    'no-iterator': 'error',
+        'no-iterator': 'error',
 
     // disallow use of labels for anything other then loops and switches
-    'no-labels': ['error', { allowLoop: false, allowSwitch: false }],
+        'no-labels': ['error', { allowLoop: false, allowSwitch: false }],
 
     // disallow unnecessary nested blocks
-    'no-lone-blocks': 'error',
+        'no-lone-blocks': 'error',
 
     // disallow creation of functions within loops
-    'no-loop-func': 'error',
+        'no-loop-func': 'error',
 
     // disallow use of multiple spaces
-    'no-multi-spaces': 'error',
+        'no-multi-spaces': 'error',
 
     // disallow use of multiline strings
-    'no-multi-str': 'error',
+        'no-multi-str': 'error',
 
     // disallow use of new operator when not part of the assignment or comparison
-    'no-new': 'error',
+        'no-new': 'error',
 
     // disallow use of new operator for Function object
-    'no-new-func': 'error',
+        'no-new-func': 'error',
 
     // disallows creating new instances of String, Number, and Boolean
-    'no-new-wrappers': 'error',
+        'no-new-wrappers': 'error',
 
     // disallow the use of object properties of the global object (Math and JSON) as functions
-    'no-obj-calls': 'error',
+        'no-obj-calls': 'error',
 
     // disallow use of (old style) octal literals
-    'no-octal': 'error',
+        'no-octal': 'error',
 
     // disallow use of octal escape sequences in string literals, such as
     // var foo = 'Copyright \251';
-    'no-octal-escape': 'error',
+        'no-octal-escape': 'error',
 
     // disallow reassignment of function parameters
     // rule: http://eslint.org/docs/rules/no-param-reassign.html
-    'no-param-reassign': 'error',
+        'no-param-reassign': 'error',
 
     // disallow usage of __proto__ property
-    'no-proto': 'error',
+        'no-proto': 'error',
 
     // disallow use of Object.prototypes builtins directly
     // http://eslint.org/docs/rules/no-prototype-builtins
-    'no-prototype-builtins': 'error',
+        'no-prototype-builtins': 'error',
 
     // disallow declaring the same variable more then once
-    'no-redeclare': 'error',
+        'no-redeclare': 'error',
 
     // disallow multiple spaces in a regular expression literal
-    'no-regex-spaces': 'error',
+        'no-regex-spaces': 'error',
 
     // disallow certain object properties
     // http://eslint.org/docs/rules/no-restricted-properties
-    'no-restricted-properties': ['error', {
-      object: 'arguments',
-      property: 'callee',
-      message: 'arguments.callee is deprecated',
-    }, {
-      property: '__defineGetter__',
-      message: 'Please use Object.defineProperty instead.',
-    }, {
-      property: '__defineSetter__',
-      message: 'Please use Object.defineProperty instead.',
-    }, {
-      object: 'Math',
-      property: 'pow',
-      message: 'Use the exponentiation operator (**) instead.',
-    }],
+        'no-restricted-properties': ['error', {
+            object: 'arguments',
+            property: 'callee',
+            message: 'arguments.callee is deprecated'
+        }, {
+            property: '__defineGetter__',
+            message: 'Please use Object.defineProperty instead.'
+        }, {
+            property: '__defineSetter__',
+            message: 'Please use Object.defineProperty instead.'
+        }, {
+            object: 'Math',
+            property: 'pow',
+            message: 'Use the exponentiation operator (**) instead.'
+        }],
 
     // disallow use of assignment in return statement
-    'no-return-assign': 'error',
+        'no-return-assign': 'error',
 
     // disallow redundant `return await`
-    'no-return-await': 'error',
+        'no-return-await': 'error',
 
     // disallow use of `javascript:` urls.
-    'no-script-url': 'error',
+        'no-script-url': 'error',
 
     // disallow self assignment
     // http://eslint.org/docs/rules/no-self-assign
-    'no-self-assign': 'error',
+        'no-self-assign': 'error',
 
     // disallow comparisons where both sides are exactly the same
-    'no-self-compare': 'error',
+        'no-self-compare': 'error',
 
     // disallow use of comma operator
-    'no-sequences': 'error',
+        'no-sequences': 'error',
 
     // disallow sparse arrays
     // e.g. [,,] - typically caused by accidentally typing extra commas
-    'no-sparse-arrays': 'error',
+        'no-sparse-arrays': 'error',
 
     // Disallow template literal placeholder syntax in regular strings
     // Probably happens when you switch from template to a regular string, but forget
     // to remove the placeholders
     // http://eslint.org/docs/rules/no-template-curly-in-string
-    'no-template-curly-in-string': 'error',
+        'no-template-curly-in-string': 'error',
 
     // restrict what can be thrown as an exception
-    'no-throw-literal': 'error',
+        'no-throw-literal': 'error',
 
     // Avoid code that looks like two expressions but is actually one
     // http://eslint.org/docs/rules/no-unexpected-multiline
-    'no-unexpected-multiline': 'error',
+        'no-unexpected-multiline': 'error',
 
     // disallow unmodified conditions of loops
     // http://eslint.org/docs/rules/no-unmodified-loop-condition
-    'no-unmodified-loop-condition': 'off',
+        'no-unmodified-loop-condition': 'off',
 
     // disallow unreachable statements after a return, throw, continue, or break statement
     // you may have intended for the code to be reachable, or may have forgotten
     // to delete it
     // http://eslint.org/docs/rules/no-unreachable
-    'no-unreachable': 'error',
+        'no-unreachable': 'error',
 
     // disallow return/throw/break/continue inside finally blocks
     // http://eslint.org/docs/rules/no-unsafe-finally
-    'no-unsafe-finally': 'error',
+        'no-unsafe-finally': 'error',
 
     // disallow negating the left operand of relational operators
     // prevents mistakes like !a && b when you mean !(a && b)
     // http://eslint.org/docs/rules/no-unsafe-negation
-    'no-unsafe-negation': 'error',
+        'no-unsafe-negation': 'error',
 
     // disallow usage of expressions in statement position
-    'no-unused-expressions': ['error', {
-      allowShortCircuit: false,
-      allowTernary: false,
-      allowTaggedTemplates: false,
-    }],
+        'no-unused-expressions': ['error', {
+            allowShortCircuit: false,
+            allowTernary: false,
+            allowTaggedTemplates: false
+        }],
 
     // disallow unused labels
     // http://eslint.org/docs/rules/no-unused-labels
-    'no-unused-labels': 'error',
+        'no-unused-labels': 'error',
 
     // disallow unnecessary .call() and .apply()
-    'no-useless-call': 'off',
+        'no-useless-call': 'off',
 
     // disallow useless string concatenation
     // http://eslint.org/docs/rules/no-useless-concat
-    'no-useless-concat': 'error',
+        'no-useless-concat': 'error',
 
     // disallow unnecessary string escaping
     // http://eslint.org/docs/rules/no-useless-escape
-    'no-useless-escape': 'error',
+        'no-useless-escape': 'error',
 
     // disallow redundant return; keywords
     // http://eslint.org/docs/rules/no-useless-return
-    'no-useless-return': 'error',
+        'no-useless-return': 'error',
 
     // disallow use of void operator
     // http://eslint.org/docs/rules/no-void
-    'no-void': 'error',
+        'no-void': 'error',
 
     // disallow usage of configurable warning terms in comments: e.g. todo
-    'no-warning-comments': ['off', { terms: ['todo', 'fixme', 'xxx'], location: 'start' }],
+        'no-warning-comments': ['off', { terms: ['todo', 'fixme', 'xxx'], location: 'start' }],
 
     // disallow use of the with statement
-    'no-with': 'error',
+        'no-with': 'error',
 
     // require using Error objects as Promise rejection reasons
     // http://eslint.org/docs/rules/prefer-promise-reject-errors
     // TODO: enable, semver-major
-    'prefer-promise-reject-errors': ['off', { allowEmptyReject: true }],
+        'prefer-promise-reject-errors': ['off', { allowEmptyReject: true }],
 
     // require use of the second argument for parseInt()
-    radix: 'error',
+        radix: 'error',
 
     // require `await` in `async function` (note: this is a horrible rule that should never be used)
     // http://eslint.org/docs/rules/require-await
-    'require-await': 'off',
+        'require-await': 'off',
 
     // disallow comparisons with the value NaN
     // NaN behaves unexpectedly, whereas isNaN(foo) does not
     // http://eslint.org/docs/rules/use-isnan
-    'use-isnan': 'error',
+        'use-isnan': 'error',
 
     // ensure that the results of typeof are compared against a valid string
     // http://eslint.org/docs/rules/valid-typeof
-    'valid-typeof': ['error', { requireStringLiterals: true }],
+        'valid-typeof': ['error', { requireStringLiterals: true }],
 
     // requires to declare all vars on top of their containing scope
-    'vars-on-top': 'error',
+        'vars-on-top': 'error',
 
     // require immediate function invocation to be wrapped in parentheses
     // http://eslint.org/docs/rules/wrap-iife.html
-    'wrap-iife': ['error', 'outside', { functionPrototypeMethods: false }],
+        'wrap-iife': ['error', 'outside', { functionPrototypeMethods: false }],
 
     // require or disallow Yoda conditions
-    yoda: 'error'
-  },
+        yoda: 'error'
+    }
 };

--- a/strict-addons/vanilla-js/package.json
+++ b/strict-addons/vanilla-js/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "eslint-config-payscale-vanilla",
+  "version": "0.0.1",
+  "description": "PayScale's eslint rules for vanilla js",
+  "main": "index.js",
+  "publishConfig": {
+    "registry": "https://registry.npmjs.com"
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/payscale/eslint-config-payscale.git"
+  },
+  "keywords": [
+    "eslint",
+    "config",
+    "lint",
+    "linter",
+    "eslintconfig",
+    "vanilla"
+  ],
+  "author": "NateW",
+  "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/payscale/eslint-config-payscale/issues"
+  },
+  "homepage": "https://github.com/payscale/eslint-config-payscale#readme",
+  "peerDependencies": {
+      "eslint": ">= 3",
+      "eslint-plugin-react": ">= 5",
+      "babel-eslint": ">= 6"
+  }
+}


### PR DESCRIPTION
- Created a "strict-addons" folder with some additional configs you can extend
- Created vanilla js strict addon, for pure vanilla js rules
- Pulled in vanilla rules from https://github.com/airbnb/javascript/blob/master/packages/eslint-config-airbnb-base/rules/best-practices.js and https://github.com/airbnb/javascript/blob/master/packages/eslint-config-airbnb-base/rules/errors.js
- Intend to add strict-addons for ES6 (might include imports in this), React, and JSX (jsx-a11y)
- Made a few minor adjustments to the eslint-config-payscale index