### PR TITLE
Add strict es6

### DIFF
--- a/strict-addons/es6/README.md
+++ b/strict-addons/es6/README.md
@@ -1,0 +1,11 @@
+# eslint-config-payscale-es6
+
+Additional lint rules for ES6.
+
+## Usage
+
+`npm install --save-dev eslint-config-payscale-es6`
+
+Then, in your .eslintrc, add it to your list of extends, e.g.:
+
+`extends: ['payscale-es6']`

--- a/strict-addons/es6/index.js
+++ b/strict-addons/es6/index.js
@@ -1,0 +1,82 @@
+/* Rules for ES6 */
+module.exports = {
+    env: {
+        es6: true
+    },
+    parserOptions: {
+        ecmaVersion: 6,
+        sourceType: 'module',
+        ecmaFeatures: {
+            generators: false,
+            objectLiteralDuplicateProperties: false
+        }
+    },
+    rules: {
+        // enforces no braces where they can be omitted
+        // http://eslint.org/docs/rules/arrow-body-style
+        'arrow-body-style': ['error', 'as-needed', {
+            requireReturnForObjectLiteral: true
+        }],
+
+        // require parens in arrow function arguments
+        // http://eslint.org/docs/rules/arrow-parens
+        'arrow-parens': ['error', 'as-needed', {
+            requireForBlockBody: true
+        }],
+
+        // require space before/after arrow function's arrow
+        // http://eslint.org/docs/rules/arrow-spacing
+        'arrow-spacing': ['error', { before: true, after: true }],
+
+        // verify super() callings in constructors
+        'constructor-super': 'error',
+
+        // enforce the spacing around the * in generator functions
+        // http://eslint.org/docs/rules/generator-star-spacing
+        'generator-star-spacing': ['error', { before: false, after: true }],
+
+        // disallow modifying variables of class declarations
+        // http://eslint.org/docs/rules/no-class-assign
+        'no-class-assign': 'error',
+
+        // disallow arrow functions where they could be confused with comparisons
+        // http://eslint.org/docs/rules/no-confusing-arrow
+        'no-confusing-arrow': ['error', {
+            allowParens: true
+        }],
+
+        // disallow modifying variables that are declared using const
+        'no-const-assign': 'error',
+
+        // disallow duplicate class members
+        // http://eslint.org/docs/rules/no-dupe-class-members
+        'no-dupe-class-members': 'error',
+
+        // disallow symbol constructor
+        // http://eslint.org/docs/rules/no-new-symbol
+        'no-new-symbol': 'error',
+
+        // disallow to use this/super before super() calling in constructors.
+        // http://eslint.org/docs/rules/no-this-before-super
+        'no-this-before-super': 'error',
+
+        // disallow useless computed property keys
+        // http://eslint.org/docs/rules/no-useless-computed-key
+        'no-useless-computed-key': 'error',
+
+        // disallow unnecessary constructor
+        // http://eslint.org/docs/rules/no-useless-constructor
+        'no-useless-constructor': 'error',
+
+        // disallow renaming import, export, and destructured assignments to the same name
+        // http://eslint.org/docs/rules/no-useless-rename
+        'no-useless-rename': ['error', {
+            ignoreDestructuring: false,
+            ignoreImport: false,
+            ignoreExport: false
+        }],
+
+        // require let or const instead of var
+        'no-var': 'error'
+    }
+};

--- a/strict-addons/es6/index.js
+++ b/strict-addons/es6/index.js
@@ -77,6 +77,58 @@ module.exports = {
         }],
 
         // require let or const instead of var
-        'no-var': 'error'
+        'no-var': 'error',
+
+        // require method and property shorthand syntax for object literals
+        // http://eslint.org/docs/rules/object-shorthand
+        'object-shorthand': ['error', 'always', {
+            ignoreConstructors: false,
+            avoidQuotes: true
+        }],
+
+        // suggest using arrow functions as callbacks
+        'prefer-arrow-callback': ['error', {
+            allowNamedFunctions: false,
+            allowUnboundThis: true
+        }],
+
+        // suggest using of const declaration for variables that are never modified after declared
+        'prefer-const': ['error', {
+            destructuring: 'any',
+            ignoreReadBeforeAssign: true
+        }],
+
+        // disallow parseInt() in favor of binary, octal, and hexadecimal literals
+        // http://eslint.org/docs/rules/prefer-numeric-literals
+        'prefer-numeric-literals': 'error',
+
+
+        // suggest using the spread operator instead of .apply()
+        // http://eslint.org/docs/rules/prefer-spread
+        'prefer-spread': 'error',
+
+        // suggest using template literals instead of string concatenation
+        // http://eslint.org/docs/rules/prefer-template
+        'prefer-template': 'error',
+
+        // disallow generator functions that do not have yield
+        // http://eslint.org/docs/rules/require-yield
+        'require-yield': 'error',
+
+        // enforce spacing between object rest-spread
+        // http://eslint.org/docs/rules/rest-spread-spacing
+        'rest-spread-spacing': ['error', 'never'],
+
+        // require a Symbol description
+        // http://eslint.org/docs/rules/symbol-description
+        'symbol-description': 'error',
+
+        // enforce usage of spacing in template strings
+        // http://eslint.org/docs/rules/template-curly-spacing
+        'template-curly-spacing': 'error',
+
+        // enforce spacing around the * in yield* expressions
+        // http://eslint.org/docs/rules/yield-star-spacing
+        'yield-star-spacing': ['error', 'after']
     }
 };

--- a/strict-addons/es6/package.json
+++ b/strict-addons/es6/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "eslint-config-payscale-es6",
+  "version": "0.0.1",
+  "description": "PayScale's eslint rules for ES6",
+  "main": "index.js",
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org"
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/payscale/eslint-config-payscale.git"
+  },
+  "keywords": [
+    "eslint",
+    "config",
+    "lint",
+    "linter",
+    "eslintconfig",
+    "es6"
+  ],
+  "author": "NateW",
+  "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/payscale/eslint-config-payscale/issues"
+  },
+  "homepage": "https://github.com/payscale/eslint-config-payscale#readme",
+  "peerDependencies": {
+      "eslint": ">= 3",
+      "eslint-plugin-react": ">= 5",
+      "babel-eslint": ">= 6"
+  }
+}

--- a/strict-addons/es6/package.json
+++ b/strict-addons/es6/package.json
@@ -29,7 +29,6 @@
   "homepage": "https://github.com/payscale/eslint-config-payscale#readme",
   "peerDependencies": {
       "eslint": ">= 3",
-      "eslint-plugin-react": ">= 5",
       "babel-eslint": ">= 6"
   }
 }

--- a/strict-addons/vanilla-js/index.js
+++ b/strict-addons/vanilla-js/index.js
@@ -1,110 +1,110 @@
 /* Rules for vanilla javascript */
 module.exports = {
     rules: {
-    // enforces getter/setter pairs in objects
+        // enforces getter/setter pairs in objects
         'accessor-pairs': 'off',
 
-    // enforces return statements in callbacks of array's methods
-    // http://eslint.org/docs/rules/array-callback-return
+        // enforces return statements in callbacks of array's methods
+        // http://eslint.org/docs/rules/array-callback-return
         'array-callback-return': 'error',
 
-    // treat var statements as if they were block scoped
+        // treat var statements as if they were block scoped
         'block-scoped-var': 'error',
 
-    // specify the maximum cyclomatic complexity allowed in a program
+        // specify the maximum cyclomatic complexity allowed in a program
         complexity: ['off', 11],
 
-    // enforce that class methods use "this"
-    // http://eslint.org/docs/rules/class-methods-use-this
+        // enforce that class methods use "this"
+        // http://eslint.org/docs/rules/class-methods-use-this
         'class-methods-use-this': ['error', {
             exceptMethods: []
         }],
 
-    // require return statements to either always or never specify values
+        // require return statements to either always or never specify values
         'consistent-return': 'error',
 
-    // must use curly braces (no if (foo) bar();)
+        // must use curly braces (no if (foo) bar();)
         curly: ['error', 'all'],
 
-    // require default case in switch statements
+        // require default case in switch statements
         'default-case': ['error', { commentPattern: '^no default$' }],
 
-    // encourages use of dot notation whenever possible
+        // encourages use of dot notation whenever possible
         'dot-notation': ['error', { allowKeywords: true }],
 
-    // enforces consistent newlines before or after dots
-    // http://eslint.org/docs/rules/dot-location
+        // enforces consistent newlines before or after dots
+        // http://eslint.org/docs/rules/dot-location
         'dot-location': ['error', 'property'],
 
-    // make sure for-in loops have an if statement
-    // this prevents unexpected behavior resulting from javascript's for-in
-    // being different from, say, C#
+        // make sure for-in loops have an if statement
+        // this prevents unexpected behavior resulting from javascript's for-in
+        // being different from, say, C#
         'guard-for-in': 'error',
 
-    // disallow the use of alert, confirm, and prompt
+        // disallow the use of alert, confirm, and prompt
         'no-alert': 'warn',
 
-    // Disallow await inside of loops
-    // http://eslint.org/docs/rules/no-await-in-loop
+        // Disallow await inside of loops
+        // http://eslint.org/docs/rules/no-await-in-loop
         'no-await-in-loop': 'error',
 
-    // disallow use of arguments.caller or arguments.callee
+        // disallow use of arguments.caller or arguments.callee
         'no-caller': 'error',
 
-    // disallow lexical declarations in case/default clauses
-    // http://eslint.org/docs/rules/no-case-declarations.html
+        // disallow lexical declarations in case/default clauses
+        // http://eslint.org/docs/rules/no-case-declarations.html
         'no-case-declarations': 'error',
 
-    // Disallow comparisons to negative zero
-    // http://eslint.org/docs/rules/no-compare-neg-zero
+        // Disallow comparisons to negative zero
+        // http://eslint.org/docs/rules/no-compare-neg-zero
         'no-compare-neg-zero': 'off',
 
-    // disallow assignment in conditional expressions
-    // this prevents difficult to spot bugs when you think you're doing a comparison,
-    // e.g. if (x = 0) { ... }
+        // disallow assignment in conditional expressions
+        // this prevents difficult to spot bugs when you think you're doing a comparison,
+        // e.g. if (x = 0) { ... }
         'no-cond-assign': ['error', 'always'],
 
-    // disallow use of constant expressions in conditions
-    // use of these rarely used characters in a regex is typically a mistake
-    // http://eslint.org/docs/rules/no-control-regex
+        // disallow use of constant expressions in conditions
+        // use of these rarely used characters in a regex is typically a mistake
+        // http://eslint.org/docs/rules/no-control-regex
         'no-constant-condition': 'warn',
 
-    // disallow control characters in regular expressions
+        // disallow control characters in regular expressions
         'no-control-regex': 'error',
 
-    // disallow division operators explicitly at beginning of regular expression
-    // http://eslint.org/docs/rules/no-div-regex
+        // disallow division operators explicitly at beginning of regular expression
+        // http://eslint.org/docs/rules/no-div-regex
         'no-div-regex': 'off',
 
-    // disallow duplicate arguments in functions
-    // never a reason to have duplicate args, as only one will pass through
-    // probably a typo
+        // disallow duplicate arguments in functions
+        // never a reason to have duplicate args, as only one will pass through
+        // probably a typo
         'no-dupe-args': 'error',
 
-    // disallow duplicate keys when creating object literals
-    // like dupe args, always a mistake, as only one key is used
+        // disallow duplicate keys when creating object literals
+        // like dupe args, always a mistake, as only one key is used
         'no-dupe-keys': 'error',
 
-    // disallow a duplicate case in a switch statement
-    // another common mistake - only one can be used
+        // disallow a duplicate case in a switch statement
+        // another common mistake - only one can be used
         'no-duplicate-case': 'error',
 
-    // disallow else after a return in an if
+        // disallow else after a return in an if
         'no-else-return': 'error',
 
-    // disallow empty blocks
-    // e.g., if (foo) {}
-    // You can put a comment in your empty block to prevent the error
-    // http://eslint.org/docs/rules/no-empty
+        // disallow empty blocks
+        // e.g., if (foo) {}
+        // You can put a comment in your empty block to prevent the error
+        // http://eslint.org/docs/rules/no-empty
         'no-empty': 'error',
 
-    // disallow the use of empty character classes in regular expressions
-    // [] in a regex doesn't match anything
-    // http://eslint.org/docs/rules/no-empty-character-class
+        // disallow the use of empty character classes in regular expressions
+        // [] in a regex doesn't match anything
+        // http://eslint.org/docs/rules/no-empty-character-class
         'no-empty-character-class': 'error',
 
-    // disallow empty functions, except for standalone funcs/arrows
-    // http://eslint.org/docs/rules/no-empty-function
+        // disallow empty functions, except for standalone funcs/arrows
+        // http://eslint.org/docs/rules/no-empty-function
         'no-empty-function': ['error', {
             allow: [
                 'arrowFunctions',
@@ -113,57 +113,57 @@ module.exports = {
             ]
         }],
 
-    // disallow empty destructuring patterns
-    // http://eslint.org/docs/rules/no-empty-pattern
+        // disallow empty destructuring patterns
+        // http://eslint.org/docs/rules/no-empty-pattern
         'no-empty-pattern': 'error',
 
-    // disallow comparisons to null without a type-checking operator
+        // disallow comparisons to null without a type-checking operator
         'no-eq-null': 'off',
 
-    // disallow use of eval()
+        // disallow use of eval()
         'no-eval': 'error',
 
-    // disallow assigning to the exception in a catch block
-    // this loses the information about the exception
-    // http://eslint.org/docs/rules/no-ex-assign
+        // disallow assigning to the exception in a catch block
+        // this loses the information about the exception
+        // http://eslint.org/docs/rules/no-ex-assign
         'no-ex-assign': 'error',
 
-    // disallow adding to native types
+        // disallow adding to native types
         'no-extend-native': 'error',
 
-    // disallow unnecessary function binding
+        // disallow unnecessary function binding
         'no-extra-bind': 'error',
 
-    // disallow double-negation boolean casts in a boolean context
-    // for example, unnecessary in an if statement's check
-    // http://eslint.org/docs/rules/no-extra-boolean-cast
+        // disallow double-negation boolean casts in a boolean context
+        // for example, unnecessary in an if statement's check
+        // http://eslint.org/docs/rules/no-extra-boolean-cast
         'no-extra-boolean-cast': 'error',
 
-    // disallow Unnecessary Labels
-    // http://eslint.org/docs/rules/no-extra-label
+        // disallow Unnecessary Labels
+        // http://eslint.org/docs/rules/no-extra-label
         'no-extra-label': 'error',
 
-    // disallow fallthrough of case statements
+        // disallow fallthrough of case statements
         'no-fallthrough': 'error',
 
-    // disallow the use of leading or trailing decimal points in numeric literals
+        // disallow the use of leading or trailing decimal points in numeric literals
         'no-floating-decimal': 'error',
 
-    // disallow overwriting functions written as function declarations
+        // disallow overwriting functions written as function declarations
         'no-func-assign': 'error',
 
-    // disallow reassignments of native objects or read-only globals
-    // http://eslint.org/docs/rules/no-global-assign
+        // disallow reassignments of native objects or read-only globals
+        // http://eslint.org/docs/rules/no-global-assign
         'no-global-assign': ['error', { exceptions: [] }],
 
-    // disallow invalid regular expression strings in the RegExp constructor
+        // disallow invalid regular expression strings in the RegExp constructor
         'no-invalid-regexp': ['error', { 'allowConstructorFlags': ['u', 'y'] }],
 
-    // deprecated in favor of no-global-assign
+        // deprecated in favor of no-global-assign
         'no-native-reassign': 'off',
 
-    // disallow implicit type conversions
-    // http://eslint.org/docs/rules/no-implicit-coercion
+        // disallow implicit type conversions
+        // http://eslint.org/docs/rules/no-implicit-coercion
         'no-implicit-coercion': ['off', {
             boolean: false,
             number: true,
@@ -171,72 +171,72 @@ module.exports = {
             allow: []
         }],
 
-    // disallow var and named functions in global scope
-    // http://eslint.org/docs/rules/no-implicit-globals
+        // disallow var and named functions in global scope
+        // http://eslint.org/docs/rules/no-implicit-globals
         'no-implicit-globals': 'off',
 
-    // disallow use of eval()-like methods
+        // disallow use of eval()-like methods
         'no-implied-eval': 'error',
 
-    // disallow this keywords outside of classes or class-like objects
+        // disallow this keywords outside of classes or class-like objects
         'no-invalid-this': 'off',
 
-    // disallow usage of __iterator__ property
+        // disallow usage of __iterator__ property
         'no-iterator': 'error',
 
-    // disallow use of labels for anything other then loops and switches
+        // disallow use of labels for anything other then loops and switches
         'no-labels': ['error', { allowLoop: false, allowSwitch: false }],
 
-    // disallow unnecessary nested blocks
+        // disallow unnecessary nested blocks
         'no-lone-blocks': 'error',
 
-    // disallow creation of functions within loops
+        // disallow creation of functions within loops
         'no-loop-func': 'error',
 
-    // disallow use of multiple spaces
+        // disallow use of multiple spaces
         'no-multi-spaces': 'error',
 
-    // disallow use of multiline strings
+        // disallow use of multiline strings
         'no-multi-str': 'error',
 
-    // disallow use of new operator when not part of the assignment or comparison
+        // disallow use of new operator when not part of the assignment or comparison
         'no-new': 'error',
 
-    // disallow use of new operator for Function object
+        // disallow use of new operator for Function object
         'no-new-func': 'error',
 
-    // disallows creating new instances of String, Number, and Boolean
+        // disallows creating new instances of String, Number, and Boolean
         'no-new-wrappers': 'error',
 
-    // disallow the use of object properties of the global object (Math and JSON) as functions
+        // disallow the use of object properties of the global object (Math and JSON) as functions
         'no-obj-calls': 'error',
 
-    // disallow use of (old style) octal literals
+        // disallow use of (old style) octal literals
         'no-octal': 'error',
 
-    // disallow use of octal escape sequences in string literals, such as
-    // var foo = 'Copyright \251';
+        // disallow use of octal escape sequences in string literals, such as
+        // var foo = 'Copyright \251';
         'no-octal-escape': 'error',
 
-    // disallow reassignment of function parameters
-    // rule: http://eslint.org/docs/rules/no-param-reassign.html
+        // disallow reassignment of function parameters
+        // rule: http://eslint.org/docs/rules/no-param-reassign.html
         'no-param-reassign': 'error',
 
-    // disallow usage of __proto__ property
+        // disallow usage of __proto__ property
         'no-proto': 'error',
 
-    // disallow use of Object.prototypes builtins directly
-    // http://eslint.org/docs/rules/no-prototype-builtins
+        // disallow use of Object.prototypes builtins directly
+        // http://eslint.org/docs/rules/no-prototype-builtins
         'no-prototype-builtins': 'error',
 
-    // disallow declaring the same variable more then once
+        // disallow declaring the same variable more then once
         'no-redeclare': 'error',
 
-    // disallow multiple spaces in a regular expression literal
+        // disallow multiple spaces in a regular expression literal
         'no-regex-spaces': 'error',
 
-    // disallow certain object properties
-    // http://eslint.org/docs/rules/no-restricted-properties
+        // disallow certain object properties
+        // http://eslint.org/docs/rules/no-restricted-properties
         'no-restricted-properties': ['error', {
             object: 'arguments',
             property: 'callee',
@@ -253,126 +253,126 @@ module.exports = {
             message: 'Use the exponentiation operator (**) instead.'
         }],
 
-    // disallow use of assignment in return statement
+        // disallow use of assignment in return statement
         'no-return-assign': 'error',
 
-    // disallow redundant `return await`
+        // disallow redundant `return await`
         'no-return-await': 'error',
 
-    // disallow use of `javascript:` urls.
+        // disallow use of `javascript:` urls.
         'no-script-url': 'error',
 
-    // disallow self assignment
-    // http://eslint.org/docs/rules/no-self-assign
+        // disallow self assignment
+        // http://eslint.org/docs/rules/no-self-assign
         'no-self-assign': 'error',
 
-    // disallow comparisons where both sides are exactly the same
+        // disallow comparisons where both sides are exactly the same
         'no-self-compare': 'error',
 
-    // disallow use of comma operator
+        // disallow use of comma operator
         'no-sequences': 'error',
 
-    // disallow sparse arrays
-    // e.g. [,,] - typically caused by accidentally typing extra commas
+        // disallow sparse arrays
+        // e.g. [,,] - typically caused by accidentally typing extra commas
         'no-sparse-arrays': 'error',
 
-    // Disallow template literal placeholder syntax in regular strings
-    // Probably happens when you switch from template to a regular string, but forget
-    // to remove the placeholders
-    // http://eslint.org/docs/rules/no-template-curly-in-string
+        // Disallow template literal placeholder syntax in regular strings
+        // Probably happens when you switch from template to a regular string, but forget
+        // to remove the placeholders
+        // http://eslint.org/docs/rules/no-template-curly-in-string
         'no-template-curly-in-string': 'error',
 
-    // restrict what can be thrown as an exception
+        // restrict what can be thrown as an exception
         'no-throw-literal': 'error',
 
-    // Avoid code that looks like two expressions but is actually one
-    // http://eslint.org/docs/rules/no-unexpected-multiline
+        // Avoid code that looks like two expressions but is actually one
+        // http://eslint.org/docs/rules/no-unexpected-multiline
         'no-unexpected-multiline': 'error',
 
-    // disallow unmodified conditions of loops
-    // http://eslint.org/docs/rules/no-unmodified-loop-condition
+        // disallow unmodified conditions of loops
+        // http://eslint.org/docs/rules/no-unmodified-loop-condition
         'no-unmodified-loop-condition': 'off',
 
-    // disallow unreachable statements after a return, throw, continue, or break statement
-    // you may have intended for the code to be reachable, or may have forgotten
-    // to delete it
-    // http://eslint.org/docs/rules/no-unreachable
+        // disallow unreachable statements after a return, throw, continue, or break statement
+        // you may have intended for the code to be reachable, or may have forgotten
+        // to delete it
+        // http://eslint.org/docs/rules/no-unreachable
         'no-unreachable': 'error',
 
-    // disallow return/throw/break/continue inside finally blocks
-    // http://eslint.org/docs/rules/no-unsafe-finally
+        // disallow return/throw/break/continue inside finally blocks
+        // http://eslint.org/docs/rules/no-unsafe-finally
         'no-unsafe-finally': 'error',
 
-    // disallow negating the left operand of relational operators
-    // prevents mistakes like !a && b when you mean !(a && b)
-    // http://eslint.org/docs/rules/no-unsafe-negation
+        // disallow negating the left operand of relational operators
+        // prevents mistakes like !a && b when you mean !(a && b)
+        // http://eslint.org/docs/rules/no-unsafe-negation
         'no-unsafe-negation': 'error',
 
-    // disallow usage of expressions in statement position
+        // disallow usage of expressions in statement position
         'no-unused-expressions': ['error', {
             allowShortCircuit: false,
             allowTernary: false,
             allowTaggedTemplates: false
         }],
 
-    // disallow unused labels
-    // http://eslint.org/docs/rules/no-unused-labels
+        // disallow unused labels
+        // http://eslint.org/docs/rules/no-unused-labels
         'no-unused-labels': 'error',
 
-    // disallow unnecessary .call() and .apply()
+        // disallow unnecessary .call() and .apply()
         'no-useless-call': 'off',
 
-    // disallow useless string concatenation
-    // http://eslint.org/docs/rules/no-useless-concat
+        // disallow useless string concatenation
+        // http://eslint.org/docs/rules/no-useless-concat
         'no-useless-concat': 'error',
 
-    // disallow unnecessary string escaping
-    // http://eslint.org/docs/rules/no-useless-escape
+        // disallow unnecessary string escaping
+        // http://eslint.org/docs/rules/no-useless-escape
         'no-useless-escape': 'error',
 
-    // disallow redundant return; keywords
-    // http://eslint.org/docs/rules/no-useless-return
+        // disallow redundant return; keywords
+        // http://eslint.org/docs/rules/no-useless-return
         'no-useless-return': 'error',
 
-    // disallow use of void operator
-    // http://eslint.org/docs/rules/no-void
+        // disallow use of void operator
+        // http://eslint.org/docs/rules/no-void
         'no-void': 'error',
 
-    // disallow usage of configurable warning terms in comments: e.g. todo
+        // disallow usage of configurable warning terms in comments: e.g. todo
         'no-warning-comments': ['off', { terms: ['todo', 'fixme', 'xxx'], location: 'start' }],
 
-    // disallow use of the with statement
+        // disallow use of the with statement
         'no-with': 'error',
 
-    // require using Error objects as Promise rejection reasons
-    // http://eslint.org/docs/rules/prefer-promise-reject-errors
-    // TODO: enable, semver-major
+        // require using Error objects as Promise rejection reasons
+        // http://eslint.org/docs/rules/prefer-promise-reject-errors
+        // TODO: enable, semver-major
         'prefer-promise-reject-errors': ['off', { allowEmptyReject: true }],
 
-    // require use of the second argument for parseInt()
+        // require use of the second argument for parseInt()
         radix: 'error',
 
-    // require `await` in `async function` (note: this is a horrible rule that should never be used)
-    // http://eslint.org/docs/rules/require-await
+        // require `await` in `async function` (note: this is a horrible rule that should never be used)
+        // http://eslint.org/docs/rules/require-await
         'require-await': 'off',
 
-    // disallow comparisons with the value NaN
-    // NaN behaves unexpectedly, whereas isNaN(foo) does not
-    // http://eslint.org/docs/rules/use-isnan
+        // disallow comparisons with the value NaN
+        // NaN behaves unexpectedly, whereas isNaN(foo) does not
+        // http://eslint.org/docs/rules/use-isnan
         'use-isnan': 'error',
 
-    // ensure that the results of typeof are compared against a valid string
-    // http://eslint.org/docs/rules/valid-typeof
+        // ensure that the results of typeof are compared against a valid string
+        // http://eslint.org/docs/rules/valid-typeof
         'valid-typeof': ['error', { requireStringLiterals: true }],
 
-    // requires to declare all vars on top of their containing scope
+        // requires to declare all vars on top of their containing scope
         'vars-on-top': 'error',
 
-    // require immediate function invocation to be wrapped in parentheses
-    // http://eslint.org/docs/rules/wrap-iife.html
+        // require immediate function invocation to be wrapped in parentheses
+        // http://eslint.org/docs/rules/wrap-iife.html
         'wrap-iife': ['error', 'outside', { functionPrototypeMethods: false }],
 
-    // require or disallow Yoda conditions
+        // require or disallow Yoda conditions
         yoda: 'error'
     }
 };

--- a/strict-addons/vanilla-js/package.json
+++ b/strict-addons/vanilla-js/package.json
@@ -29,7 +29,6 @@
   "homepage": "https://github.com/payscale/eslint-config-payscale#readme",
   "peerDependencies": {
       "eslint": ">= 3",
-      "eslint-plugin-react": ">= 5",
       "babel-eslint": ">= 6"
   }
 }


### PR DESCRIPTION
Took es6 rules from airbnb. Some highlights:

* prefer string templates over string concatenation
* remove certain useless code, such as constructors
* es6 variable linting, such as preferring const and let over var, requiring const if never changed, and preventing consts from being reassigned
* arrow function linting, including recommending arrow functions in callbacks, avoiding ambiguous arrow functions, and handling spacing and parentheses around arrow functions

Other changes:
* made some fixes to the vanilla js comment formatting
* remove unnecessary peer dependency on react eslint config