### PR TITLE
Imports

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+node_modules

--- a/README.md
+++ b/README.md
@@ -2,3 +2,7 @@
 PayScale's sharable eslint config
 
 For more information on sharable configs, visit: http://eslint.org/docs/developer-guide/shareable-configs
+
+For additional lint rules, check out:
+* [eslint-config-payscale-vanilla](https://www.npmjs.com/package/eslint-config-payscale-vanilla) - vanilla javascript lint config
+* [eslint-config-payscale-es6](https://www.npmjs.com/package/eslint-config-payscale-es6) - lint config for es6 syntax and imports

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-payscale",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "PayScale's sharable eslint config",
   "main": "index.js",
   "publishConfig": {

--- a/strict-addons/es6/imports.js
+++ b/strict-addons/es6/imports.js
@@ -37,11 +37,11 @@ module.exports = {
 
         // ensure named imports coupled with named exports
         // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/named.md
-        'import/named': 'warn',
+        'import/named': 'error',
 
         // ensure default import coupled with default export
         // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/default.md
-        'import/default': 'warn',
+        'import/default': 'error',
 
         // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/namespace.md
         'import/namespace': 'error',
@@ -88,7 +88,7 @@ module.exports = {
 
         // disallow non-import statements appearing before import statements
         // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/first.md
-        'import/first': ['warn', 'absolute-first'],
+        'import/first': ['error', 'absolute-first'],
 
         // disallow duplicate imports
         // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-duplicates.md
@@ -96,7 +96,7 @@ module.exports = {
 
         // Ensure consistent use of file extension within the import path
         // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/extensions.md
-        'import/extensions': ['warn', 'always', {
+        'import/extensions': ['error', 'always', {
             js: 'never',
             jsx: 'never'
         }],

--- a/strict-addons/es6/imports.js
+++ b/strict-addons/es6/imports.js
@@ -31,44 +31,35 @@ module.exports = {
     },
 
     rules: {
-    // Static analysis:
-
-    // ensure imports point to files/modules that can be resolved
-    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-unresolved.md
+        // ensure imports point to files/modules that can be resolved
+        // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-unresolved.md
         'import/no-unresolved': ['error', { commonjs: true, caseSensitive: true }],
 
-    // ensure named imports coupled with named exports
-    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/named.md
+        // ensure named imports coupled with named exports
+        // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/named.md
         'import/named': 'warn',
 
-    // ensure default import coupled with default export
-    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/default.md
+        // ensure default import coupled with default export
+        // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/default.md
         'import/default': 'warn',
 
-    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/namespace.md
+        // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/namespace.md
         'import/namespace': 'error',
 
-    // Helpful warnings:
-
-    // disallow invalid exports, e.g. multiple defaults
-    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/export.md
+        // disallow invalid exports, e.g. multiple defaults
+        // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/export.md
         'import/export': 'error',
 
-    // do not allow a default import name to match a named export
-    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-named-as-default.md
+        // do not allow a default import name to match a named export
+        // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-named-as-default.md
         'import/no-named-as-default': 'error',
 
-    // warn on accessing default export property names that are also named exports
-    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-named-as-default-member.md
+        // warn on accessing default export property names that are also named exports
+        // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-named-as-default-member.md
         'import/no-named-as-default-member': 'error',
 
-    // disallow use of jsdoc-marked-deprecated imports
-    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-deprecated.md
-        'import/no-deprecated': 'off',
-
-    // Forbid the use of extraneous packages
-    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-extraneous-dependencies.md
-    // paths are treated both as absolute paths, and relative to process.cwd()
+        // Forbid the use of extraneous packages
+        // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-extraneous-dependencies.md
         'import/no-extraneous-dependencies': ['error', {
             devDependencies: [
                 '**/*.test.js', // ignore for tests
@@ -79,108 +70,60 @@ module.exports = {
             ]
         }],
 
-    // Forbid mutable exports
-    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-mutable-exports.md
+        // Forbid mutable exports
+        // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-mutable-exports.md
         'import/no-mutable-exports': 'error',
 
-    // Module systems:
 
-    // disallow require()
-    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-commonjs.md
+        // disallow require()
+        // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-commonjs.md
         'import/no-commonjs': 'off',
 
-    // disallow AMD require/define
-    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-amd.md
+        // disallow AMD require/define
+        // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-amd.md
         'import/no-amd': 'error',
 
-    // No Node.js builtin modules
-    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-nodejs-modules.md
+        // No Node.js builtin modules
+        // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-nodejs-modules.md
         'import/no-nodejs-modules': 'off',
 
-    // Style guide:
-
-    // disallow non-import statements appearing before import statements
-    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/first.md
+        // disallow non-import statements appearing before import statements
+        // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/first.md
         'import/first': ['warn', 'absolute-first'],
 
-    // disallow duplicate imports
-    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-duplicates.md
+        // disallow duplicate imports
+        // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-duplicates.md
         'import/no-duplicates': 'error',
 
-    // disallow namespace imports
-    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-namespace.md
-        'import/no-namespace': 'off',
-
-    // Ensure consistent use of file extension within the import path
-    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/extensions.md
+        // Ensure consistent use of file extension within the import path
+        // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/extensions.md
         'import/extensions': ['warn', 'always', {
             js: 'never',
             jsx: 'never'
         }],
 
-    // Enforce a convention in module import order
-    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/order.md
-        'import/order': ['off'],
-
-    // Require a newline after the last import/require in a group
-    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/newline-after-import.md
+        // Require a newline after the last import/require in a group
+        // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/newline-after-import.md
         'import/newline-after-import': 'error',
 
-    // Require modules with a single export to use a default export
-    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/prefer-default-export.md
+        // Require modules with a single export to use a default export
+        // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/prefer-default-export.md
         'import/prefer-default-export': 'error',
 
-    // Restrict which files can be imported in a given folder
-    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-restricted-paths.md
-        'import/no-restricted-paths': 'off',
-
-    // Forbid modules to have too many dependencies
-    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/max-dependencies.md
-        'import/max-dependencies': ['off', { max: 10 }],
-
-    // Forbid import of modules using absolute paths
-    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-absolute-path.md
+        // Forbid import of modules using absolute paths
+        // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-absolute-path.md
         'import/no-absolute-path': 'error',
 
-    // Forbid require() calls with expressions
-    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-dynamic-require.md
+        // Forbid require() calls with expressions
+        // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-dynamic-require.md
         'import/no-dynamic-require': 'error',
 
-    // prevent importing the submodules of other modules
-    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-internal-modules.md
-        'import/no-internal-modules': ['off', {
-            allow: []
-        }],
-
-    // Warn if a module could be mistakenly parsed as a script by a consumer
-    // leveraging Unambiguous JavaScript Grammar
-    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/unambiguous.md
-    // this should not be enabled until this proposal has at least been *presented* to TC39.
-    // At the moment, it's not a thing.
-        'import/unambiguous': 'off',
-
-    // Forbid Webpack loader syntax in imports
-    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-webpack-loader-syntax.md
+        // Forbid Webpack loader syntax in imports
+        // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-webpack-loader-syntax.md
         'import/no-webpack-loader-syntax': 'error',
 
-    // Prevent unassigned imports
-    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-unassigned-import.md
-    // importing for side effects is perfectly acceptable, if you need side effects.
-        'import/no-unassigned-import': 'off',
-
-    // Prevent importing the default as if it were named
-    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-named-default.md
+        // Prevent importing the default as if it were named
+        // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-named-default.md
         'import/no-named-default': 'error',
-
-    // Reports if a module's default export is unnamed
-    // https://github.com/benmosher/eslint-plugin-import/blob/d9b712ac7fd1fddc391f7b234827925c160d956f/docs/rules/no-anonymous-default-export.md
-        'import/no-anonymous-default-export': ['off', {
-            allowArray: false,
-            allowArrowFunction: false,
-            allowAnonymousClass: false,
-            allowAnonymousFunction: false,
-            allowLiteral: false,
-            allowObject: false
-        }]
     }
 };

--- a/strict-addons/es6/imports.js
+++ b/strict-addons/es6/imports.js
@@ -74,7 +74,6 @@ module.exports = {
         // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-mutable-exports.md
         'import/no-mutable-exports': 'error',
 
-
         // disallow require()
         // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-commonjs.md
         'import/no-commonjs': 'off',
@@ -124,6 +123,6 @@ module.exports = {
 
         // Prevent importing the default as if it were named
         // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-named-default.md
-        'import/no-named-default': 'error',
+        'import/no-named-default': 'error'
     }
 };

--- a/strict-addons/es6/imports.js
+++ b/strict-addons/es6/imports.js
@@ -1,0 +1,186 @@
+/* rules for es6 imports */
+
+module.exports = {
+    env: {
+        es6: true
+    },
+    parserOptions: {
+        ecmaVersion: 6,
+        sourceType: 'module'
+    },
+    plugins: [
+        'import'
+    ],
+
+    settings: {
+        'import/resolver': {
+            node: {
+                extensions: ['.js', '.json']
+            }
+        },
+        'import/extensions': [
+            '.js',
+            '.jsx'
+        ],
+        'import/core-modules': [
+        ],
+        'import/ignore': [
+            'node_modules',
+            '\\.(scss|css|less|svg|json)$'
+        ]
+    },
+
+    rules: {
+    // Static analysis:
+
+    // ensure imports point to files/modules that can be resolved
+    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-unresolved.md
+        'import/no-unresolved': ['error', { commonjs: true, caseSensitive: true }],
+
+    // ensure named imports coupled with named exports
+    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/named.md
+        'import/named': 'warn',
+
+    // ensure default import coupled with default export
+    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/default.md
+        'import/default': 'warn',
+
+    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/namespace.md
+        'import/namespace': 'error',
+
+    // Helpful warnings:
+
+    // disallow invalid exports, e.g. multiple defaults
+    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/export.md
+        'import/export': 'error',
+
+    // do not allow a default import name to match a named export
+    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-named-as-default.md
+        'import/no-named-as-default': 'error',
+
+    // warn on accessing default export property names that are also named exports
+    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-named-as-default-member.md
+        'import/no-named-as-default-member': 'error',
+
+    // disallow use of jsdoc-marked-deprecated imports
+    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-deprecated.md
+        'import/no-deprecated': 'off',
+
+    // Forbid the use of extraneous packages
+    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-extraneous-dependencies.md
+    // paths are treated both as absolute paths, and relative to process.cwd()
+        'import/no-extraneous-dependencies': ['error', {
+            devDependencies: [
+                '**/*.test.js', // ignore for tests
+                '**/webpack.config.js', // webpack config
+                '**/webpack.config.*.js', // webpack config
+                '**/gulpfile.js', // gulp config
+                '**/gulpfile.*.js' // gulp config
+            ]
+        }],
+
+    // Forbid mutable exports
+    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-mutable-exports.md
+        'import/no-mutable-exports': 'error',
+
+    // Module systems:
+
+    // disallow require()
+    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-commonjs.md
+        'import/no-commonjs': 'off',
+
+    // disallow AMD require/define
+    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-amd.md
+        'import/no-amd': 'error',
+
+    // No Node.js builtin modules
+    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-nodejs-modules.md
+        'import/no-nodejs-modules': 'off',
+
+    // Style guide:
+
+    // disallow non-import statements appearing before import statements
+    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/first.md
+        'import/first': ['warn', 'absolute-first'],
+
+    // disallow duplicate imports
+    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-duplicates.md
+        'import/no-duplicates': 'error',
+
+    // disallow namespace imports
+    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-namespace.md
+        'import/no-namespace': 'off',
+
+    // Ensure consistent use of file extension within the import path
+    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/extensions.md
+        'import/extensions': ['warn', 'always', {
+            js: 'never',
+            jsx: 'never'
+        }],
+
+    // Enforce a convention in module import order
+    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/order.md
+        'import/order': ['off'],
+
+    // Require a newline after the last import/require in a group
+    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/newline-after-import.md
+        'import/newline-after-import': 'error',
+
+    // Require modules with a single export to use a default export
+    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/prefer-default-export.md
+        'import/prefer-default-export': 'error',
+
+    // Restrict which files can be imported in a given folder
+    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-restricted-paths.md
+        'import/no-restricted-paths': 'off',
+
+    // Forbid modules to have too many dependencies
+    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/max-dependencies.md
+        'import/max-dependencies': ['off', { max: 10 }],
+
+    // Forbid import of modules using absolute paths
+    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-absolute-path.md
+        'import/no-absolute-path': 'error',
+
+    // Forbid require() calls with expressions
+    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-dynamic-require.md
+        'import/no-dynamic-require': 'error',
+
+    // prevent importing the submodules of other modules
+    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-internal-modules.md
+        'import/no-internal-modules': ['off', {
+            allow: []
+        }],
+
+    // Warn if a module could be mistakenly parsed as a script by a consumer
+    // leveraging Unambiguous JavaScript Grammar
+    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/unambiguous.md
+    // this should not be enabled until this proposal has at least been *presented* to TC39.
+    // At the moment, it's not a thing.
+        'import/unambiguous': 'off',
+
+    // Forbid Webpack loader syntax in imports
+    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-webpack-loader-syntax.md
+        'import/no-webpack-loader-syntax': 'error',
+
+    // Prevent unassigned imports
+    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-unassigned-import.md
+    // importing for side effects is perfectly acceptable, if you need side effects.
+        'import/no-unassigned-import': 'off',
+
+    // Prevent importing the default as if it were named
+    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-named-default.md
+        'import/no-named-default': 'error',
+
+    // Reports if a module's default export is unnamed
+    // https://github.com/benmosher/eslint-plugin-import/blob/d9b712ac7fd1fddc391f7b234827925c160d956f/docs/rules/no-anonymous-default-export.md
+        'import/no-anonymous-default-export': ['off', {
+            allowArray: false,
+            allowArrowFunction: false,
+            allowAnonymousClass: false,
+            allowAnonymousFunction: false,
+            allowLiteral: false,
+            allowObject: false
+        }]
+    }
+};

--- a/strict-addons/es6/index.js
+++ b/strict-addons/es6/index.js
@@ -3,6 +3,9 @@ module.exports = {
     env: {
         es6: true
     },
+    extends: [
+        './imports.js'
+    ],
     parserOptions: {
         ecmaVersion: 6,
         sourceType: 'module',

--- a/strict-addons/es6/package.json
+++ b/strict-addons/es6/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-payscale-es6",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "PayScale's eslint rules for ES6",
   "main": "index.js",
   "publishConfig": {
@@ -29,6 +29,7 @@
   "homepage": "https://github.com/payscale/eslint-config-payscale#readme",
   "peerDependencies": {
       "eslint": ">= 3",
-      "babel-eslint": ">= 6"
+      "babel-eslint": ">= 6",
+      "eslint-plugin-import": "^2.7.0"
   }
 }


### PR DESCRIPTION
Added some rules from airbnb (after vetting them on our RC code) around imports and exports in ES6. I set as warnings certain rules that were fairly prevalent in our code, such as not having a default export or not doing named exports correctly. Hopefully these warnings still help moving forward to prevent some nasty bugs such as the one we saw on Friday with importing a directory instead of a file.