### PR TITLE
fix: Adding react.fragment rule

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-payscale",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "PayScale's sharable eslint config",
   "main": "index.js",
   "publishConfig": {

--- a/rules/react.js
+++ b/rules/react.js
@@ -13,6 +13,9 @@ module.exports = {
       }
     ],
 
+    // enforce shorthand or standard form for React fragments 
+    "react/jsx-fragments": ["error", "syntax"],
+
     // enforce spaces between curly braces
     "react/jsx-curly-spacing": "error",
 


### PR DESCRIPTION
Making it so that <React.Fragment> will become <></> (shorthand)