### PR TITLE
chore: Version bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-payscale",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "PayScale's sharable eslint config",
   "main": "index.js",
   "publishConfig": {


### PR DESCRIPTION
1.2.1 apparently throws an error in teamcity saying that 1.2.1 had already been published; maybe 1.2.2 will work